### PR TITLE
refactor: minor refactoring types

### DIFF
--- a/botanim_bot/db.py
+++ b/botanim_bot/db.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import Iterable
-from typing import Any, LiteralString, Optional
+from typing import Any, LiteralString
 
 import aiosqlite
 
@@ -15,7 +15,7 @@ async def get_db() -> aiosqlite.Connection:
 
 
 async def fetch_all(
-    sql: LiteralString, params: Optional[Iterable[Any]] = None
+    sql: LiteralString, params: Iterable[Any] | None = None
 ) -> list[dict]:
     cursor = await _get_cursor(sql, params)
     rows = await cursor.fetchall()
@@ -27,7 +27,7 @@ async def fetch_all(
 
 
 async def fetch_one(
-    sql: LiteralString, params: Optional[Iterable[Any]] = None
+    sql: LiteralString, params: Iterable[Any] | None = None
 ) -> dict | None:
     cursor = await _get_cursor(sql, params)
     row_ = await cursor.fetchone()
@@ -40,12 +40,12 @@ async def fetch_one(
 
 async def execute(
     sql: LiteralString,
-    params: Optional[Iterable[Any]] = None,
+    params: Iterable[Any] | None = None,
     *,
     autocommit: bool = True
 ) -> None:
     db = await get_db()
-    args: tuple[LiteralString, Optional[Iterable[Any]]] = (sql, params)
+    args: tuple[LiteralString, Iterable[Any] | None] = (sql, params)
     await db.execute(*args)
     if autocommit:
         await db.commit()
@@ -60,10 +60,10 @@ async def _async_close_db() -> None:
 
 
 async def _get_cursor(
-    sql: LiteralString, params: Optional[Iterable[Any]]
+    sql: LiteralString, params: Iterable[Any] | None
 ) -> aiosqlite.Cursor:
     db = await get_db()
-    args: tuple[LiteralString, Optional[Iterable[Any]]] = (sql, params)
+    args: tuple[LiteralString, Iterable[Any] | None] = (sql, params)
     cursor = await db.execute(*args)
     db.row_factory = aiosqlite.Row
     return cursor


### PR DESCRIPTION
Вкусовщина, но всё же

Łukasz Langa a Python core developer, replied on a YouTube live related to the Python 3.10 release that `Type | None` **is preferred over** `Optional[Type]` for Python 3.10+.

https://stackoverflow.com/questions/69440494/python-3-10-optionaltype-or-type-none